### PR TITLE
Update Red Hat Keys

### DIFF
--- a/keys/redhat/RPM-GPG-KEY-redhat7-beta
+++ b/keys/redhat/RPM-GPG-KEY-redhat7-beta
@@ -1,0 +1,1 @@
+RPM-GPG-KEY-redhat6-beta

--- a/keys/redhat/RPM-GPG-KEY-redhat7-legacy-former
+++ b/keys/redhat/RPM-GPG-KEY-redhat7-legacy-former
@@ -1,0 +1,1 @@
+RPM-GPG-KEY-redhat6-legacy-former

--- a/keys/redhat/RPM-GPG-KEY-redhat7-legacy-release
+++ b/keys/redhat/RPM-GPG-KEY-redhat7-legacy-release
@@ -1,0 +1,1 @@
+RPM-GPG-KEY-redhat6-legacy-release

--- a/keys/redhat/RPM-GPG-KEY-redhat7-legacy-rhx
+++ b/keys/redhat/RPM-GPG-KEY-redhat7-legacy-rhx
@@ -1,0 +1,1 @@
+RPM-GPG-KEY-redhat6-legacy-rhx

--- a/keys/redhat/RPM-GPG-KEY-redhat7-release
+++ b/keys/redhat/RPM-GPG-KEY-redhat7-release
@@ -1,0 +1,1 @@
+RPM-GPG-KEY-redhat6-release


### PR DESCRIPTION
Red Hat signing keys (available from
https://access.redhat.com/security/team/key) in Red Hat Enterprise Linux
7 are the same from Red Hat Enterprise Linux 6.