### PR TITLE
Add symlink from CentOS 8 to CentOS Official key

### DIFF
--- a/keys/centos/RPM-GPG-KEY-CentOS-8
+++ b/keys/centos/RPM-GPG-KEY-CentOS-8
@@ -1,0 +1,1 @@
+RPM-GPG-KEY-CentOS-Official


### PR DESCRIPTION
Previous CentOS releases (5,6,7) had GPG keys named by this pattern:
`RPM-GPG-KEY-CentOS-{releasever}`

Come CentOS 8, it has changed and the key is now named `RPM-GPG-KEY-CentOS-!Official!`.

---

Having a key for CentOS 8 thats follows the old pattern would make it easier
for retrace-server to use proper key for packagage verification without workarounds.

GPG key changes in retrace-server:
https://github.com/abrt/retrace-server/pull/295

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>